### PR TITLE
Implement token authentication using Django's built-in user management

### DIFF
--- a/WorkplaceViolencePredictionAPI/API/serializers.py
+++ b/WorkplaceViolencePredictionAPI/API/serializers.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import User
 from rest_framework import serializers
 
 """

--- a/WorkplaceViolencePredictionAPI/API/views.py
+++ b/WorkplaceViolencePredictionAPI/API/views.py
@@ -65,7 +65,7 @@ class HelloWorldViewSet(viewsets.ViewSet):
 
 
 # Class-based view (not ViewSet!)
-class HelloAdmin(APIView):
+class HelloWorldAdmin(APIView):
     """
     View to list all users in the system.
 

--- a/WorkplaceViolencePredictionAPI/API/views.py
+++ b/WorkplaceViolencePredictionAPI/API/views.py
@@ -43,8 +43,11 @@ class TokenViewSet(viewsets.ViewSet):
 
     def list(self, request):
         tokens = Token.objects.filter(user=request.user)
-        token_list = [{'key': token.key} for token in tokens]  # there should only be 1 at any given time
-        return JsonResponse(token_list)
+
+        if tokens.exists():
+            return JsonResponse({'key': tokens[0].key}, status=status.HTTP_200_OK)
+        else:
+            return JsonResponse({'error': 'Token does not exist'}, status=status.HTTP_400_BAD_REQUEST)
 
     def create(self, request):
         user = request.user
@@ -56,6 +59,7 @@ class TokenViewSet(viewsets.ViewSet):
             return JsonResponse({'error': 'Token already exists'}, status=status.HTTP_400_BAD_REQUEST)
 
 
+# Hello world ViewSet
 class HelloViewSet(viewsets.ViewSet):
     @action(detail=False, permission_classes=[permissions.AllowAny])
     def world(self, request):

--- a/WorkplaceViolencePredictionAPI/API/views.py
+++ b/WorkplaceViolencePredictionAPI/API/views.py
@@ -1,12 +1,11 @@
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, permissions, authentication
 from rest_framework.authtoken.models import Token
-from rest_framework.decorators import api_view
 from rest_framework.views import APIView
 
-from WorkplaceViolencePredictionAPI.API.serializers import UserSerializer, GroupSerializer
+from WorkplaceViolencePredictionAPI.API.serializers import UserSerializer
 
 """
 Django REST framework allows you to combine the logic for a set of related views in a single class, called a ViewSet.

--- a/WorkplaceViolencePredictionAPI/settings.py
+++ b/WorkplaceViolencePredictionAPI/settings.py
@@ -76,6 +76,14 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': BASE_DIR / 'db.sqlite3',
+    },
+    'external': {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": "sweng",
+        "USER": "avery",
+        "PASSWORD": "bobbit82",
+        "HOST": "73.248.135.215",
+        "PORT": "3306"
     }
 }
 

--- a/WorkplaceViolencePredictionAPI/urls.py
+++ b/WorkplaceViolencePredictionAPI/urls.py
@@ -24,8 +24,8 @@ from WorkplaceViolencePredictionAPI.API import views
 # for ViewSets not associated with a model, we need to explicitly define the basename
 router = routers.DefaultRouter()
 router.register(r'users', views.UserViewSet)
-router.register(r'get_token', views.TokenViewSet, basename='get_token')
 router.register(r'hello', views.HelloViewSet, basename='hello')
+router.register(r'token', views.TokenViewSet, basename='token')
 
 urlpatterns = [
     path('admin/', admin.site.urls),  # built-in admin portal for Django

--- a/WorkplaceViolencePredictionAPI/urls.py
+++ b/WorkplaceViolencePredictionAPI/urls.py
@@ -30,5 +30,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include(router.urls)),
     path('api/auth/', include('rest_framework.urls')),
-    path('api/hello_admin/', views.HelloAdmin.as_view(), name='hello-admin')
+    path('api/hello_admin/', views.HelloWorldAdmin.as_view(), name='hello-admin')
 ]

--- a/WorkplaceViolencePredictionAPI/urls.py
+++ b/WorkplaceViolencePredictionAPI/urls.py
@@ -20,15 +20,15 @@ from rest_framework import routers
 
 from WorkplaceViolencePredictionAPI.API import views
 
-router = routers.DefaultRouter()  # routers only work with ViewSets, not regular Views
+# routers only work with ViewSets, not regular Views
+# for ViewSets not associated with a model, we need to explicitly define the basename
+router = routers.DefaultRouter()
 router.register(r'users', views.UserViewSet)
-# for custom ViewSets, we need to explicitly define the basename
-router.register(r'hello', views.HelloWorldViewSet, basename='hello')
-router.register(r'get_token', views.UserTokenViewSet, basename='token')
+router.register(r'get_token', views.TokenViewSet, basename='get_token')
+router.register(r'hello', views.HelloViewSet, basename='hello')
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('api/', include(router.urls)),
-    path('api/auth/', include('rest_framework.urls')),
-    path('api/hello_admin/', views.HelloWorldAdmin.as_view(), name='hello-admin')
+    path('admin/', admin.site.urls),  # built-in admin portal for Django
+    path('api/', include(router.urls)),  # router paths defined above
+    path('api/auth/', include('rest_framework.urls')),  # login/out for browser view
 ]


### PR DESCRIPTION
This commit introduces two ViewSets: `HelloViewSet` and `TokenViewSet`. `HelloViewSet` is simply a demo of the authentication, which we can use in our sprint 1 review. `TokenViewSet` provides two methods: `list` and `create`, which correspond to `GET` and `POST` requests respectively. Only one token can exist for a user at a time, so a `GET` request to `/api/token` will only return a 200 status when a token already exists for a user. Likewise, a `POST` request to `/api/token/` will only return a 200 status when a token does _not_ already exist for a user and one is created. 

> [!IMPORTANT]
> Note the trailing slash in `/api/token/`, `POST` requests must have a trailing slash!

Additionally, `TokenViewSet` is be the **only** ViewSet that implements BasicAuthentication. All others should implement TokenAuthentication.